### PR TITLE
mark-devkit: Bump virtual/perl-Time-HiRes-1.976.400

### DIFF
--- a/virtual/perl-Time-HiRes/perl-Time-HiRes-1.976.400.ebuild
+++ b/virtual/perl-Time-HiRes/perl-Time-HiRes-1.976.400.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-Time-HiRes-1.976.400 for branch mark-xl by mark-bot