### PR TITLE
mark-devkit: Bump virtual/perl-Digest-1.170.100_rc-r10

### DIFF
--- a/virtual/perl-Digest/perl-Digest-1.170.100_rc-r10.ebuild
+++ b/virtual/perl-Digest/perl-Digest-1.170.100_rc-r10.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* =dev-lang/perl-5.30* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-Digest-1.170.100_rc-r10 for branch mark-xl by mark-bot