### PR TITLE
mark-devkit: Bump virtual/perl-Sys-Syslog-0.360.0

### DIFF
--- a/virtual/perl-Sys-Syslog/perl-Sys-Syslog-0.360.0.ebuild
+++ b/virtual/perl-Sys-Syslog/perl-Sys-Syslog-0.360.0.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-Sys-Syslog-0.360.0 for branch mark-unstable by mark-bot