### PR TITLE
mark-devkit: Bump virtual/perl-Text-Tabs+Wrap-2013.52.300-r10

### DIFF
--- a/virtual/perl-Text-Tabs+Wrap/perl-Text-Tabs+Wrap-2013.52.300-r10.ebuild
+++ b/virtual/perl-Text-Tabs+Wrap/perl-Text-Tabs+Wrap-2013.52.300-r10.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for Text::Tabs and Text::Wrap, also distributed as Text::Tabs+Wrap"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* =dev-lang/perl-5.30* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-Text-Tabs+Wrap-2013.52.300-r10 for branch mark-unstable by mark-bot