### PR TITLE
mark-devkit: Bump virtual/perl-Test-Simple-1.302.175

### DIFF
--- a/virtual/perl-Test-Simple/perl-Test-Simple-1.302.175.ebuild
+++ b/virtual/perl-Test-Simple/perl-Test-Simple-1.302.175.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<dev-perl/Test-Tester-0.114.0
+	!<dev-perl/Test-use-ok-0.160.0
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-Test-Simple-1.302.175 for branch mark-unstable by mark-bot