### PR TITLE
mark-devkit: Bump virtual/perl-if-0.60.800-r3

### DIFF
--- a/virtual/perl-if/perl-if-0.60.800-r3.ebuild
+++ b/virtual/perl-if/perl-if-0.60.800-r3.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* =dev-lang/perl-5.30* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-if-0.60.800-r3 for branch mark-unstable by mark-bot