### PR TITLE
mark-devkit: Bump virtual/perl-Compress-Raw-Bzip2-2.93.0

### DIFF
--- a/virtual/perl-Compress-Raw-Bzip2/perl-Compress-Raw-Bzip2-2.93.0.ebuild
+++ b/virtual/perl-Compress-Raw-Bzip2/perl-Compress-Raw-Bzip2-2.93.0.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-Compress-Raw-Bzip2-2.93.0 for branch mark-unstable by mark-bot