### PR TITLE
mark-devkit: [mark-xl] Bump virtual/perl-IO-Zlib-1.100.0-r14

### DIFF
--- a/virtual/perl-IO-Zlib/perl-IO-Zlib-1.100.0-r14.ebuild
+++ b/virtual/perl-IO-Zlib/perl-IO-Zlib-1.100.0-r14.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* =dev-lang/perl-5.30* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-IO-Zlib-1.100.0-r14 for branch mark-xl by mark-bot