### PR TITLE
mark-devkit: [mark-xl] Bump virtual/perl-Archive-Tar-2.360.0

### DIFF
--- a/virtual/perl-Archive-Tar/perl-Archive-Tar-2.360.0.ebuild
+++ b/virtual/perl-Archive-Tar/perl-Archive-Tar-2.360.0.ebuild
@@ -1,0 +1,13 @@
+
+EAPI=7
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+"


### PR DESCRIPTION
Automatic bump of package virtual/perl-Archive-Tar-2.360.0 for branch mark-xl by mark-bot