### PR TITLE
mark-devkit: [mark-xl] Bump virtual/perl-IO-Compress-2.93.0

### DIFF
--- a/virtual/perl-IO-Compress/perl-IO-Compress-2.93.0.ebuild
+++ b/virtual/perl-IO-Compress/perl-IO-Compress-2.93.0.ebuild
@@ -1,0 +1,18 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for ${PN#perl-}"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	|| ( =dev-lang/perl-5.32* ~perl-core/${PN#perl-}-${PV} )
+	dev-lang/perl:=
+	!<perl-core/${PN#perl-}-${PV}
+	!>perl-core/${PN#perl-}-${PV}-r999
+	>=virtual/perl-Compress-Raw-Zlib-${PV}
+	>=virtual/perl-Compress-Raw-Bzip2-${PV}
+"
+# Dependencies on Compress-Raw* must be kept in step
+# but sometimes not .... use ${PV} when you can.


### PR DESCRIPTION
Automatic bump of package virtual/perl-IO-Compress-2.93.0 for branch mark-xl by mark-bot